### PR TITLE
Added wasd movement, proxy url, and made canvas wider

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,14 +75,10 @@
                </label>
                
             </div>
-
-            <div class="col s12">
-               <div id="canvas-container" width="100%"></div>
-               <!--<canvas id="render-canvas" height="100%"></canvas>-->
-            </div>
-
+            
          </div>
       </div>
+      <div id="canvas-container" width="100%" tabindex='1'></div>
 
       <!-- Texture atlas -->
       <img id="atlas" src="https://raw.githubusercontent.com/misode/deepslate-demo/main/atlas.png" alt="Texture atlas" crossorigin="anonymous" hidden>
@@ -96,7 +92,7 @@
 
             if (remoteUrl) {
                console.log("Loading file from", remoteUrl);
-               redFileUrl(remoteUrl);
+               readFileURL(remoteUrl);
             }
          });
 
@@ -109,7 +105,8 @@
             }
          }
 
-         function redFileUrl(url) {
+         function readFileURL(url) {
+            var proxyUrl = 'https://api.allorigins.win/raw?url=' + url;
             var request = new XMLHttpRequest();
             request.responseType = 'blob';
             request.onreadystatechange = function () {
@@ -124,7 +121,7 @@
                   }
                }
             };
-            request.open('GET', url, true);
+            request.open('GET', proxyUrl, true);
             request.send();
          }
 

--- a/src/script.js
+++ b/src/script.js
@@ -152,6 +152,49 @@ function createRenderer(structure) {
 
     requestAnimationFrame(render);
   })
+
+  const moveDist = 0.2;
+  const keyMoves = {
+    w: [0, 0, moveDist],
+    s: [0, 0, -moveDist],
+    a: [moveDist, 0, 0],
+    d: [-moveDist, 0, 0],
+    Shift: [0, moveDist, 0],
+    ' ': [0, -moveDist, 0]
+  };
+  let pressedKeys = new Set();
+  
+  document.addEventListener('keydown', evt => {
+    if (evt.key in keyMoves) {
+      evt.preventDefault();
+      pressedKeys.add(evt.key);
+    }
+  });
+  
+  document.addEventListener('keyup', evt => {
+    pressedKeys.delete(evt.key);
+  });
+  
+  setInterval(() => {
+    if(pressedKeys.size == 0) return;
+    let offset = vec3.create();
+    vec3.set(offset, 0, 0, 0);
+    for (const key of pressedKeys) {
+        if (key in keyMoves) {
+            vec3.add(offset, offset, keyMoves[key]);
+        }
+    }
+    
+    // This makes keypresses move with respect to your facing direction.
+    // i.e. 'w' when looking down moves down.
+    // Feels pretty weird but could be useful for some things, leaving it as a comment:
+
+    // vec3.rotateX(offset, offset, [0,0,0], -xRotation);
+    
+    vec3.rotateY(offset, offset, [0,0,0], -yRotation);
+    vec3.add(cameraPos, cameraPos, offset);
+    requestAnimationFrame(render);
+  }, 1000/60);
 }
 
 function structureFromLitematic(litematic) {


### PR DESCRIPTION
Try it here: https://joakimthorsen.github.io/litematic-viewer/?remote-url=https://cdn.discordapp.com/attachments/908089307636588584/1065749582664958053/Tree_Farm_Finished.litematic
I'd recommend scrolling down two notches to make the canvas fit the screen better

Fixes both #1 and #2.
Also moved the canvas out of the container to remove the empty space around the viewer that looked identical to the canvas background (in light mode, at least)

There is sometimes a problem with ghost keys, in which case you have to press the key once more to get it to stop. Not sure if there's really any better way to do it though: https://stackoverflow.com/questions/13640061/get-a-list-of-all-currently-pressed-keys-in-javascript